### PR TITLE
feat(editor): download-knop voor bewaard leerlingwerk per pagina (#30)

### DIFF
--- a/book/_static/sql-editors.css
+++ b/book/_static/sql-editors.css
@@ -100,6 +100,28 @@ html[data-theme="dark"] {
   font-size: .875rem;
   color: var(--sql-error);
 }
+/* Downloadbalk (#30): één knop per pagina, onder de laatste interactieve cel,
+   die alle celinhoud als één .sql-bestand exporteert. Zelfde vlakke taal als
+   de toolbar: hairline, raised vlak, mono-eyebrow. */
+.sql-download-bar {
+  display: flex; gap: .5rem .75rem; align-items: center;
+  flex-wrap: wrap;
+  margin: 1.5rem 0 1rem;
+  padding: .5rem .75rem;
+  border: 1px solid var(--sql-border-strong);
+  border-radius: var(--sql-radius-lg);
+  background: var(--sql-surface-raised);
+}
+.sql-download-bar .title {
+  font-family: var(--sql-font-mono);
+  font-size: var(--sql-label-size);
+  font-weight: 400;
+  text-transform: uppercase;
+  letter-spacing: var(--sql-label-tracking);
+  color: var(--sql-text-muted);
+}
+.sql-download-bar .sql-live-note { flex: 1 1 16rem; }
+.sql-download-bar .sql-live-btn { margin-left: auto; }
 
 /* ── CodeMirror: syntaxkleuren (klassen uit sql-editors.js) ──
    Chrome-styling (achtergrond, gutter, selectie, tooltip) zit in het

--- a/book/_static/sql-editors.js
+++ b/book/_static/sql-editors.js
@@ -16,7 +16,9 @@
 //     Run ververst (CREATE TABLE-lessen);
 //   - leerlingqueries worden per cel bewaard in localStorage (#14): bij het
 //     heropenen van de pagina staat het eigen werk er weer, en de knop
-//     "Startcode" zet de originele opgave terug.
+//     "Startcode" zet de originele opgave terug;
+//   - onder de laatste cel staat een knop "Download mijn queries" (#30) die
+//     alle celinhoud van de pagina als één .sql-bestand exporteert.
 
 import {
   EditorState, Compartment,
@@ -367,6 +369,51 @@ async function openSchema() {
   mod.openSchemaOverlay({ worker, sharedId: SHARED_ID });
 }
 
+// --- Download van het eigen werk (#30) ---
+// Eén knop per pagina die de actuele inhoud van alle interactieve cellen als
+// één .sql-bestand exporteert, met een commentaarkop per cel ("-- cel 3").
+// Handig indienformaat, en de aangeraden uitweg voor wie op meerdere
+// toestellen werkt: de opslag uit #14 is per browser/toestel. De export leest
+// rechtstreeks uit de editors (niet uit localStorage), dus hij werkt ook als
+// opslag geblokkeerd is.
+function exportFileName() {
+  const page = (location.pathname.split('/').pop() || '')
+    .replace(/\.html?$/i, '')
+    .replace(/[^\w.-]+/g, '_');
+  return `queries-${page || 'pagina'}.sql`;
+}
+
+function buildSqlExport() {
+  const parts = editorsApi.map(
+    ed => `-- cel ${ed.index + 1}\n${ed.getValue().trim()}\n`,
+  );
+  return `-- Mijn queries — ${location.pathname}\n\n${parts.join('\n')}`;
+}
+
+function downloadQueries() {
+  const blob = new Blob([buildSqlExport()], { type: 'application/sql' });
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement('a');
+  a.href = url;
+  a.download = exportFileName();
+  document.body.appendChild(a);
+  a.click();
+  a.remove();
+  setTimeout(() => URL.revokeObjectURL(url), 1000);
+}
+
+function addDownloadBar(lastCell) {
+  const bar = document.createElement('div');
+  bar.className = 'sql-download-bar';
+  bar.innerHTML = `
+    <span class="title">Mijn werk</span>
+    <span class="sql-live-note">Je werk wordt per browser bewaard — als bestand neem je het mee naar een ander toestel, of dien je het in.</span>
+    <button class="sql-live-btn download">Download mijn queries</button>
+  `;
+  bar.querySelector('.download').addEventListener('click', downloadQueries);
+  lastCell.after(bar);
+}
+
 // --- Editors opzetten ---
 function editorExtensions(langCompartment, run, onDocChange) {
   return [
@@ -467,6 +514,9 @@ function initEditors(blocks) {
       onChange: (cb) => { changeListeners.push(cb); },
     });
   });
+
+  // Downloadknop (#30) onder de laatste interactieve cel van de pagina.
+  addDownloadBar(blocks[blocks.length - 1].cell);
 
   // Nog niet weggeschreven wijzigingen (debounce) alsnog bewaren bij het
   // verlaten of verbergen van de pagina.


### PR DESCRIPTION
Laatste chunk van de batch — follow-up uit #14.

- **#30** (`4f47618`) — Per lespagina een "Download mijn queries"-balk (Plink-stijl, onder de laatste sql-live cel) die alle celinhoud als één .sql-bestand exporteert met een `-- cel N`-kop per cel. Leest live editorinhoud via `window.sqlLive.editors`, dus de multi-device-uitweg werkt ook bij geblokkeerde localStorage.

## Test plan (uitgevoerd)

- `teachbooks build book` groen met 0 warnings.
- Headless e2e: download op pagina met bewaard werk levert `queries-01_Starten_met_sql.sql` met `-- cel 1..11`-koppen die bewaard, live-onbewaard en startcode-cellen correct weergeven; geen balk op pagina's zonder sql-live cellen; werkt met geblokkeerde localStorage; nul consolefouten in alle drie scenario's.

Closes #30

🤖 Generated with [Claude Code](https://claude.com/claude-code)