### PR TITLE
chore(book): deel 2 en 3 gewisseld — eerst Power BI/Big Data, dan databases creëren (#36)

### DIFF
--- a/book/_toc.yml
+++ b/book/_toc.yml
@@ -28,17 +28,6 @@ parts:
       - file: chapters/SQL/05c_Detective
       - file: chapters/SQL/05d_Query_race
     - file: chapters/SQL/06_Herhaling
-  - caption: Databases Ontwerpen met ERD's
-    numbered: false
-    style: numerical
-    restart_numbering: false
-    chapters:
-    - file: chapters/ERD/01_Inleiding_tot_ERD
-    - file: chapters/ERD/02_normalisatie
-    - file: chapters/ERD/03_ERD_tekenen
-    - file: chapters/ERD/04_de_voetbal
-    - file: chapters/ERD/05_de_cafetaria
-    - file: chapters/ERD/06_client_server
   - caption: Big Data
     numbered: false
     style: numerical
@@ -55,4 +44,15 @@ parts:
       title: "6. Onderzoeksopdracht: belastingdruk"
     - file: chapters/BIG_DATA/07_Overhoring
     - file: chapters/BIG_DATA/08_Eindopdracht
+  - caption: Databases Ontwerpen met ERD's
+    numbered: false
+    style: numerical
+    restart_numbering: false
+    chapters:
+    - file: chapters/ERD/01_Inleiding_tot_ERD
+    - file: chapters/ERD/02_normalisatie
+    - file: chapters/ERD/03_ERD_tekenen
+    - file: chapters/ERD/04_de_voetbal
+    - file: chapters/ERD/05_de_cafetaria
+    - file: chapters/ERD/06_client_server
 

--- a/book/chapters/BIG_DATA/01_Inleiding.ipynb
+++ b/book/chapters/BIG_DATA/01_Inleiding.ipynb
@@ -13,7 +13,7 @@
     "\n",
     "## 1. Wat maakt big data anders?\n",
     "\n",
-    "Bij klassieke bedrijfsdata werk je vaak met een goed afgebakende databank. De structuur ligt vooraf vast. Je weet welke tabellen er zijn, welke velden ze bevatten en hoe die tabellen aan elkaar gekoppeld zijn. Een webshop heeft bijvoorbeeld tabellen zoals `customers`, `orders`, `products` en `order_lines`. Die data is meestal **genormaliseerd**, zodat er zo weinig mogelijk redundantie is en de databank goed onderhoudbaar blijft.\n",
+    "Bij klassieke bedrijfsdata werk je vaak met een goed afgebakende databank. De structuur ligt vooraf vast. Je weet welke tabellen er zijn, welke velden ze bevatten en hoe die tabellen aan elkaar gekoppeld zijn. Een webshop heeft bijvoorbeeld tabellen zoals `customers`, `orders`, `products` en `order_lines`. Die data is verdeeld over meerdere tabellen die naar elkaar verwijzen, zodat elk gegeven maar op één plaats bewaard wordt en de databank goed onderhoudbaar blijft. Hoe je zo'n structuur zelf ontwerpt, leer je in het volgende deel.\n",
     "\n",
     "Big data werkt anders. Daar vertrek je vaak niet vanuit een databank die speciaal voor jouw toepassing gebouwd werd. Je vertrekt eerder vanuit een grote bestaande gegevensbron en stelt jezelf de vraag: **welke informatie kan ik hieruit halen?** Dat vraagt een andere manier van denken. Je bent minder bezig met transacties invoeren en meer met onderzoeken, filteren, vergelijken en interpreteren.\n",
     "\n",
@@ -67,7 +67,7 @@
     "\n",
     "Dat onderscheid is zo belangrijk dat er aparte begrippen voor bestaan.\n",
     "\n",
-    "Een **operationele database** ondersteunt de dagelijkse werking van een organisatie. Ze is gebouwd om transacties snel en correct te verwerken: een bestelling registreren, een adres wijzigen, een voorraad bijwerken. De webshop-database uit de SQL-lessen is daar een typisch voorbeeld van: genormaliseerd, voortdurend in verandering, en altijd up-to-date.\n",
+    "Een **operationele database** ondersteunt de dagelijkse werking van een organisatie. Ze is gebouwd om transacties snel en correct te verwerken: een bestelling registreren, een adres wijzigen, een voorraad bijwerken. De webshop-database uit de SQL-lessen is daar een typisch voorbeeld van: opgesplitst in kleine tabellen die naar elkaar verwijzen, voortdurend in verandering, en altijd up-to-date.\n",
     "\n",
     "Een **datawarehouse** — ook wel een **analytische database** genoemd — is gebouwd om te analyseren. De gegevens komen vaak uit meerdere bronnen, worden na het laden zelden nog gewijzigd, en zijn zo geordend dat je er vlot bevragingen, samenvattingen en visualisaties op kan uitvoeren. Vlot kunnen analyseren is er belangrijker dan het vermijden van redundantie.\n",
     "\n",
@@ -136,7 +136,7 @@
     "2. Daarna volgen drie **onderzoeksopdrachten** met echte Eurostat-data: eerst volledig begeleid, daarna steeds zelfstandiger.\n",
     "3. Na de eerste onderzoeksopdracht staan we stil bij **misleidende grafieken**: je leert hoe een visualisatie een verkeerd beeld kan geven, en waarom dat soms bewust gebeurt.\n",
     "4. Daarna volgt een **overhoring** waarin je zelfstandig een Eurostat-dataset analyseert.\n",
-    "5. We sluiten het jaar af met een **eindopdracht**: je kiest zelf een dataset uit een keuzemenu en formuleert er je eigen onderzoeksvragen bij.\n"
+    "5. We sluiten dit deel af met een **eindopdracht**: je kiest zelf een dataset uit een keuzemenu en formuleert er je eigen onderzoeksvragen bij.\n"
    ]
   }
  ],

--- a/book/chapters/BIG_DATA/02_Power_BI.ipynb
+++ b/book/chapters/BIG_DATA/02_Power_BI.ipynb
@@ -37,7 +37,7 @@
    "source": [
     "## 2. Van database naar dataset\n",
     "\n",
-    "Power BI werkt het liefst met een **platte tabel**: één rij per gebeurtenis, met alle bijbehorende informatie in kolommen ernaast. Onze webshop-database is net **niet** plat: de gegevens zitten genormaliseerd in vier tabellen (`customers`, `orders`, `products` en `order_lines`). Dat is ideaal om bestellingen correct op te slaan, maar onhandig om te analyseren.\n",
+    "Power BI werkt het liefst met een **platte tabel**: één rij per gebeurtenis, met alle bijbehorende informatie in kolommen ernaast. Onze webshop-database is net **niet** plat: de gegevens zitten verspreid over vier tabellen (`customers`, `orders`, `products` en `order_lines`). Dat is ideaal om bestellingen correct op te slaan, maar onhandig om te analyseren.\n",
     "\n",
     "Gelukkig weet jij intussen hoe je die tabellen weer aan elkaar plakt. Wij hebben de database alvast voor jou omgezet naar een Excel-bestand, met precies het soort query dat jij in de SQL-lessen leerde schrijven:\n",
     "\n",

--- a/book/chapters/BIG_DATA/08_Eindopdracht.ipynb
+++ b/book/chapters/BIG_DATA/08_Eindopdracht.ipynb
@@ -7,7 +7,7 @@
    "source": [
     "# 8. Eindopdracht: kies je eigen dataset\n",
     "\n",
-    "Het hele jaar door kreeg je bij elke opdracht een dataset van mij, met instructies erbij. In een echt onderzoek werkt het net omgekeerd: je vertrekt van een vraag of een thema, en je gaat zelf op zoek naar data waarmee je die vraag kan beantwoorden. Dat is precies de vaardigheid die deze eindopdracht toetst: **een dataset kiezen en inschatten of ze bruikbaar is voor jouw onderzoek**.\n",
+    "In dit deel kreeg je bij elke opdracht een dataset van mij, met instructies erbij. In een echt onderzoek werkt het net omgekeerd: je vertrekt van een vraag of een thema, en je gaat zelf op zoek naar data waarmee je die vraag kan beantwoorden. Dat is precies de vaardigheid die deze eindopdracht toetst: **een dataset kiezen en inschatten of ze bruikbaar is voor jouw onderzoek**.\n",
     "\n",
     "Helemaal in het wilde weg zoeken doen we niet — het internet staat vol datasets die er interessant uitzien, maar onbruikbaar blijken zodra je ze downloadt. Daarom werk je met een **keuzemenu**: acht datasets waarvan ik zeker weet dat ze werken. Jij kiest er één, formuleert er zelf je onderzoeksvragen bij, en toetst met een checklist of je keuze standhoudt.\n",
     "\n",
@@ -323,7 +323,7 @@
     "* Staat bij elke visualisatie een interpretatie?\n",
     "* Is je rapport verzorgd en consistent?\n",
     "\n",
-    "Dit is de laatste opdracht van het jaar. Maak er iets van waar je trots op bent. Veel succes!"
+    "Dit is de laatste opdracht van dit deel. Maak er iets van waar je trots op bent. Veel succes!"
    ]
   }
  ],

--- a/book/intro.md
+++ b/book/intro.md
@@ -8,10 +8,8 @@ In dit vak bouwen we stap voor stap inzicht op in de wereld van **relationele da
 De cursus bestaat uit drie delen:
 
 1. **Databases bevragen met SQL** — je leert gegevens opvragen uit een relationele databank met **SQL**, zowel in een **browseromgeving** als lokaal met **DB Browser for SQLite**. Vanaf de eerste lessen werk je met een **realistische webshopcasus**, en pas je elke techniek meteen toe op de grotere **AdventureWorks-database** van een fietsenfabrikant. Als afsluiter bevraag je de **facturatiedatabase** van een Vlaamse groothandel, met echte boekhoudvragen over btw-tarieven en vervaldatums.
-2. **Databases ontwerpen met ERD's** — je leert hoe een goed ontwerp zorgt voor **integriteit, efficiëntie en betrouwbaarheid**: van **normalisatie** en **constraints** tot **foreign keys** en **ERD-schema's**. Je ontwerpt zelf databanken voor realistische situaties en bouwt ze na in DB Browser. Tot slot voer je je ontwerp uit op een echte **serverdatabase in de cloud**, rechtstreeks vanuit de browser.
-3. **Big data** — je analyseert en visualiseert echte **Eurostat-datasets** met **Power BI**, en leert kritisch omgaan met grote hoeveelheden data.
-
-Als afsluiting van het schooljaar pas je alles toe in de **onderzoeksopdrachten** en een **overhoring**, waarin je zelfstandig Eurostat-data analyseert met Power BI en conclusies trekt uit je visualisaties.
+2. **Big data** — je analyseert en visualiseert echte **Eurostat-datasets** met **Power BI**, en leert kritisch omgaan met grote hoeveelheden data. In **onderzoeksopdrachten**, een **overhoring** en een **eindopdracht** analyseer je steeds zelfstandiger Eurostat-data en trek je conclusies uit je visualisaties.
+3. **Databases ontwerpen met ERD's** — je leert hoe een goed ontwerp zorgt voor **integriteit, efficiëntie en betrouwbaarheid**: van **normalisatie** en **constraints** tot **foreign keys** en **ERD-schema's**. Je ontwerpt zelf databanken voor realistische situaties en bouwt ze na in DB Browser. Tot slot voer je je ontwerp uit op een echte **serverdatabase in de cloud**, rechtstreeks vanuit de browser.
 
 Deze cursus combineert **denken als een ontwikkelaar** met **redeneren als een data-analist**.
 We werken probleemgericht, praktisch en met oog voor kwaliteit — zodat je niet enkel leert *hoe* iets werkt, maar vooral *waarom*.

--- a/tests/test_book_structure.py
+++ b/tests/test_book_structure.py
@@ -1,0 +1,240 @@
+"""Structuurtests voor het boek: deelvolgorde, kruisverwijzingen en prev/next-flow (issue #36).
+
+Draaien met de projectomgeving (PyYAML zit in de teachbooks-installatie):
+
+    .venv/Scripts/python.exe tests/test_book_structure.py
+
+Het bestand is ook door pytest te verzamelen. De HTML-tests lezen de gebouwde
+site in book/_build/html en worden overgeslagen zolang die ontbreekt; bouw
+eerst met `teachbooks build book`.
+"""
+from __future__ import annotations
+
+import html
+import json
+import re
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+BOOK = ROOT / "book"
+HTML = BOOK / "_build" / "html"
+
+# Volgorde van de delen sinds issue #36: eerst bevragen, dan analyseren
+# (Power BI / Big Data), pas daarna zelf databases ontwerpen (ERD).
+EXPECTED_PARTS = [
+    "Databases Bevragen met SQL",
+    "Big Data",
+    "Databases Ontwerpen met ERD's",
+]
+
+# Grenspagina's tussen de delen, in leesvolgorde (paden relatief aan book/).
+LAST_SQL = "chapters/SQL/06_Herhaling"
+FIRST_BIG_DATA = "chapters/BIG_DATA/01_Inleiding"
+LAST_BIG_DATA = "chapters/BIG_DATA/08_Eindopdracht"
+FIRST_ERD = "chapters/ERD/01_Inleiding_tot_ERD"
+LAST_ERD = "chapters/ERD/06_client_server"
+
+# Formuleringen die de oude volgorde (Big Data als slot van het jaar) of een
+# nummering van de delen veronderstellen. Beide zijn sinds de wissel fout.
+STALE_PHRASES = [
+    r"\bdeel [23]\b",
+    r"\b(tweede|derde|laatste) deel\b",
+    r"\bhet (school)?jaar af\b",
+    r"\blaatste opdracht van het (school)?jaar\b",
+    r"\bhele (school)?jaar door\b",
+    r"\bafsluiting van het (school)?jaar\b",
+]
+
+# Woordenschat uit het ERD-deel die een Big Data-pagina niet mag veronderstellen.
+ERD_VOCABULARY = [
+    r"\bERD\b",
+    r"normalis",  # normalisatie, genormaliseerd, ...
+    r"\bforeign key",
+    r"referenti[eë]le integriteit",
+]
+
+# Vooruitwijzingen die het ERD-deel niet mag maken: er komt geen deel meer na.
+ERD_FORWARD_REFERENCES = [
+    r"Power ?BI",
+    r"Eurostat",
+    r"\bbig data\b",
+    r"\b(volgende|derde|laatste) deel\b",
+    r"\bstraks in\b",
+]
+
+
+class Skip(Exception):
+    """Test overgeslagen (zonder pytest)."""
+
+
+def skip(reason: str) -> None:
+    if "pytest" in sys.modules:
+        import pytest
+
+        pytest.skip(reason)
+    raise Skip(reason)
+
+
+def load_toc() -> dict:
+    import yaml
+
+    return yaml.safe_load((BOOK / "_toc.yml").read_text(encoding="utf-8"))
+
+
+def markdown_of(notebook: Path) -> str:
+    cells = json.loads(notebook.read_text(encoding="utf-8"))["cells"]
+    return "\n".join("".join(c["source"]) for c in cells if c["cell_type"] == "markdown")
+
+
+def chapter_notebooks(part_dir: str) -> list[Path]:
+    # Niet recursief: .ipynb_checkpoints/ hoort er niet bij.
+    found = sorted((BOOK / "chapters" / part_dir).glob("*.ipynb"))
+    assert found, f"geen notebooks gevonden in chapters/{part_dir}"
+    return found
+
+
+def find_phrases(text: str, patterns: list[str]) -> list[str]:
+    hits = []
+    for pattern in patterns:
+        for m in re.finditer(pattern, text, flags=re.IGNORECASE):
+            start, end = max(0, m.start() - 40), min(len(text), m.end() + 40)
+            hits.append(f"/{pattern}/ -> ...{text[start:end]!r}...")
+    return hits
+
+
+def assert_free_of(paths: list[Path], patterns: list[str], reader) -> None:
+    problems = []
+    for path in paths:
+        for hit in find_phrases(reader(path), patterns):
+            problems.append(f"{path.relative_to(ROOT)}: {hit}")
+    assert not problems, "\n".join(problems)
+
+
+def page_html(rel: str) -> str:
+    page = HTML / f"{rel}.html"
+    if not HTML.is_dir():
+        skip("book/_build/html ontbreekt; bouw eerst met `teachbooks build book`")
+    assert page.is_file(), f"gebouwde pagina ontbreekt: {page.relative_to(ROOT)}"
+    return page.read_text(encoding="utf-8")
+
+
+def prev_next(rel: str) -> tuple[str | None, str | None]:
+    """Geef de (prev, next)-doelen van een pagina als paden relatief aan book/, zonder .html."""
+    text = page_html(rel)
+    page_dir = Path(rel).parent
+
+    def target(css_class: str) -> str | None:
+        m = re.search(rf'<a\s+class="{css_class}"[^>]*?href="([^"]+)"', text, flags=re.DOTALL)
+        if not m:
+            return None
+        href = html.unescape(m.group(1)).split("#")[0]
+        parts: list[str] = []
+        for piece in (page_dir / href).as_posix().split("/"):
+            if piece == "..":
+                parts.pop()
+            elif piece and piece != ".":
+                parts.append(piece)
+        return "/".join(parts).removesuffix(".html")
+
+    return target("left-prev"), target("right-next")
+
+
+# --- brontests ------------------------------------------------------------
+
+
+def test_toc_part_order() -> None:
+    captions = [part["caption"] for part in load_toc()["parts"]]
+    assert captions == EXPECTED_PARTS, f"volgorde in _toc.yml: {captions}"
+
+
+def test_toc_files_exist() -> None:
+    missing = []
+
+    def walk(entries):
+        for entry in entries:
+            if "file" in entry:
+                path = BOOK / entry["file"]
+                if not (path.with_suffix(".ipynb").is_file() or path.with_suffix(".md").is_file()):
+                    missing.append(entry["file"])
+            walk(entry.get("sections", []))
+
+    for part in load_toc()["parts"]:
+        walk(part["chapters"])
+    assert not missing, f"in _toc.yml maar niet op schijf: {missing}"
+
+
+def test_intro_lists_parts_in_toc_order() -> None:
+    intro = (BOOK / "intro.md").read_text(encoding="utf-8")
+    listed = re.findall(r"^\d+\. \*\*(.+?)\*\*", intro, flags=re.MULTILINE)
+    assert [t.lower() for t in listed] == [t.lower() for t in EXPECTED_PARTS], (
+        f"intro.md beschrijft de delen als {listed}, _toc.yml als {EXPECTED_PARTS}"
+    )
+
+
+def test_sources_have_no_stale_part_references() -> None:
+    notebooks = [nb for part in ("SQL", "BIG_DATA", "ERD") for nb in chapter_notebooks(part)]
+    assert_free_of(notebooks, STALE_PHRASES, markdown_of)
+    assert_free_of([BOOK / "intro.md"], STALE_PHRASES, lambda p: p.read_text(encoding="utf-8"))
+
+
+def test_big_data_does_not_assume_erd_knowledge() -> None:
+    assert_free_of(chapter_notebooks("BIG_DATA"), ERD_VOCABULARY, markdown_of)
+
+
+def test_erd_does_not_point_to_a_later_part() -> None:
+    assert_free_of(chapter_notebooks("ERD"), ERD_FORWARD_REFERENCES, markdown_of)
+
+
+# --- tests op de gebouwde site (wat de leerling ziet) ----------------------
+
+
+def test_html_sidebar_lists_parts_in_order() -> None:
+    captions = [
+        html.unescape(c).strip()
+        for c in re.findall(r'class="caption-text">(.*?)</span>', page_html("intro"))
+    ]
+    assert captions == EXPECTED_PARTS, f"zijbalk toont de delen als {captions}"
+
+
+def test_html_prev_next_flow_between_parts() -> None:
+    assert prev_next(LAST_SQL)[1] == FIRST_BIG_DATA, prev_next(LAST_SQL)
+    assert prev_next(FIRST_BIG_DATA)[0] == LAST_SQL, prev_next(FIRST_BIG_DATA)
+    assert prev_next(LAST_BIG_DATA)[1] == FIRST_ERD, prev_next(LAST_BIG_DATA)
+    assert prev_next(FIRST_ERD)[0] == LAST_BIG_DATA, prev_next(FIRST_ERD)
+    assert prev_next(LAST_ERD)[1] is None, "het ERD-deel sluit het boek af"
+
+
+def test_html_has_no_stale_part_references() -> None:
+    pages = ["intro", LAST_SQL, FIRST_BIG_DATA, LAST_BIG_DATA, FIRST_ERD, LAST_ERD]
+    problems = []
+    for rel in pages:
+        text = re.sub(r"<[^>]+>", "", page_html(rel))  # tags weg, tekst blijft
+        problems += [f"{rel}: {hit}" for hit in find_phrases(text, STALE_PHRASES)]
+    assert not problems, "\n".join(problems)
+
+
+# --- runner zonder pytest --------------------------------------------------
+
+
+def main() -> int:
+    tests = [(name, fn) for name, fn in globals().items() if name.startswith("test_") and callable(fn)]
+    counts = {"passed": 0, "failed": 0, "skipped": 0}
+    for name, fn in tests:
+        try:
+            fn()
+        except Skip as exc:
+            counts["skipped"] += 1
+            print(f"SKIP {name} - {exc}")
+        except AssertionError as exc:
+            counts["failed"] += 1
+            print(f"FAIL {name}\n    " + str(exc).replace("\n", "\n    "))
+        else:
+            counts["passed"] += 1
+            print(f"PASS {name}")
+    print(f"{counts['passed']} passed, {counts['failed']} failed, {counts['skipped']} skipped")
+    return 1 if counts["failed"] else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

- **#36** — Swapped the ERD and Big Data parts in `book/_toc.yml` so the order is now SQL → Power BI/Big Data → databases creëren (ERD), aligning with the onderzoeksopdracht in the economics lessons. `intro.md`'s three-part description is reordered (the "afsluiting van het schooljaar" sentence folded into the Big Data item since ERD now closes the year). The only implicit ERD dependencies in the Big Data part were reworded (three uses of "genormaliseerd" in 01/02; "het jaar af" / "laatste opdracht van het jaar" / "hele jaar door" in 01/08). ERD chapters had no forward references and are unchanged.
- Adds `tests/test_book_structure.py` (9 checks on the built HTML: sidebar order, prev/next footers across part boundaries, no stale "deel 2/3" wording). Not yet wired into CI — see follow-up.

Note for reviewers: an incremental `teachbooks build` leaves prev/next footers of *unchanged* pages stale after a toc reorder; CI builds clean, which is correct. The new test caught this.

## Test plan

- `teachbooks build book` from an empty `_build`: exit 0, 0 WARNING/ERROR lines (baseline before the change: also 0).
- `pytest tests/test_book_structure.py`: 9/9 pass on the clean build; 7/9 fail on the unpatched baseline build (proves the test detects the swap).
- grep of built HTML: no "deel 2/3", "tweede/derde/laatste deel", "het jaar af", "laatste opdracht van het jaar", "hele jaar door", "afsluiting van het schooljaar".
- Sidebar order SQL → Big Data → ERD; footers SQL/06 → BIG_DATA/01, BIG_DATA/08 → ERD/01, ERD/06 has no next.
- Edited notebooks pass `nbformat.validate`. (No repo formatter/linter exists.)

## Follow-ups

- #39 — run `tests/` in CI (the only workflow builds/deploys, never tests). Queued in this batch as its own PR.

Closes #36

🤖 Generated with [Claude Code](https://claude.com/claude-code)