### PR TITLE
ci: run tests/ (structure, node unit, Playwright e2e) on every push (#39)

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,77 @@
+# Tests op elke push: de structuurtests op de bronnen en de gebouwde HTML
+# (tests/test_book_structure.py), de Node-unittests van de pure editor-modules
+# (tests/*.test.mjs, via pytest aangeroepen) en de Playwright/Chromium-e2e-tests
+# van de SQL-editor (tests/test_sql_editor.py). Bewust los van
+# call-deploy-book.yml: een rode test blokkeert de publicatie niet, maar kleurt
+# de check op de PR wel rood (issue #39).
+#
+# De tests slaan zichzelf over als de build, Node, Playwright of Chromium
+# ontbreekt. In CI zou zo'n stille skip een groene run opleveren zonder dat er
+# iets getest is; daarom zet TESTS_FAIL_ON_SKIP=1 (zie tests/conftest.py) elke
+# skip om in een failure.
+name: tests
+
+on:
+  push:
+    # Net als call-deploy-book.yml: elke branch, zodat de check ook op PR's uit
+    # deze repo verschijnt; alleen als iets verandert dat de build of de tests raakt.
+    branches:
+      - '**'
+    paths:
+      - book/**
+      - tests/**
+      - requirements.txt
+      - requirements-dev.txt
+      - package.json
+      - package-lock.json
+      - .github/workflows/tests.yml
+  workflow_dispatch:
+
+# Een nieuwe push naar dezelfde branch vervangt een nog lopende testrun.
+concurrency:
+  group: tests-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  tests:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: actions/setup-python@v7
+        with:
+          python-version: '3.11'   # zelfde versie als de TeachBooks deploy-workflow
+          cache: pip
+          cache-dependency-path: |
+            requirements.txt
+            requirements-dev.txt
+
+      - uses: actions/setup-node@v7   # node --test voor tests/*.test.mjs
+        with:
+          node-version: 22
+
+      - name: Install Python dependencies
+        run: python -m pip install -r requirements-dev.txt
+
+      - name: Install Chromium for Playwright
+        run: playwright install --with-deps chromium
+
+      - name: Build the book
+        run: teachbooks build book
+
+      - name: Run tests
+        env:
+          TESTS_FAIL_ON_SKIP: "1"
+        shell: bash   # -o pipefail: de exitcode van pytest telt, niet die van tee
+        run: |
+          mkdir -p test-output
+          pytest tests -ra -v --junitxml=test-output/junit.xml 2>&1 | tee test-output/pytest.log
+
+      - name: Upload test output
+        if: failure()
+        uses: actions/upload-artifact@v7
+        with:
+          name: test-output
+          path: test-output/
+          if-no-files-found: ignore

--- a/.gitignore
+++ b/.gitignore
@@ -30,6 +30,7 @@ coverage.xml
 *.py,cover
 .hypothesis/
 .pytest_cache/
+test-output/
 
 # Translations
 *.mo

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,43 @@
+"""Gedeelde pytest-configuratie voor tests/.
+
+De tests slaan zichzelf over zodra iets in de omgeving ontbreekt: de gebouwde
+site (book/_build/html), Node, Playwright of Chromium. Lokaal is dat handig,
+maar in CI zou zo'n stille skip een groene run opleveren zonder dat er iets
+getest is. Met TESTS_FAIL_ON_SKIP=1 telt elke skip daarom als failure; de
+workflow .github/workflows/tests.yml zet die variabele aan (issue #39).
+
+    TESTS_FAIL_ON_SKIP=1 pytest tests
+"""
+from __future__ import annotations
+
+import os
+
+import pytest
+
+FAIL_ON_SKIP = os.environ.get("TESTS_FAIL_ON_SKIP", "").strip().lower() not in ("", "0", "false", "no")
+
+
+def _skip_as_failure(report) -> None:
+    """Zet een skipped-rapport om in een failed-rapport, met de skip-reden als melding."""
+    if not (FAIL_ON_SKIP and report.skipped) or hasattr(report, "wasxfail"):
+        return
+    longrepr = report.longrepr
+    reason = longrepr[2] if isinstance(longrepr, tuple) and len(longrepr) == 3 else str(longrepr)
+    report.outcome = "failed"
+    report.longrepr = f"[TESTS_FAIL_ON_SKIP=1] overgeslagen test telt als failure: {reason}"
+
+
+@pytest.hookimpl(wrapper=True)
+def pytest_runtest_makereport(item, call):
+    """Skips tijdens setup (fixtures) of in de test zelf."""
+    report = yield
+    _skip_as_failure(report)
+    return report
+
+
+@pytest.hookimpl(wrapper=True)
+def pytest_make_collect_report(collector):
+    """Skips op moduleniveau (pytest.importorskip, allow_module_level=True)."""
+    report = yield
+    _skip_as_failure(report)
+    return report


### PR DESCRIPTION
## Summary

- **#39** — Adds `.github/workflows/tests.yml`: on push to every branch (paths-filtered to `book/**`, `tests/**`, `requirements*.txt`, `package*.json`, the workflow itself) plus `workflow_dispatch`; ubuntu, 30 min timeout, Python 3.11 (the deploy workflow's version) with pip cache, Node 22, `playwright install --with-deps chromium`, clean `teachbooks build book`, then `pytest tests -ra -v` with junit + tee'd log uploaded as an artifact on failure. Concurrency cancels superseded runs.
- Adds `tests/conftest.py` with a `TESTS_FAIL_ON_SKIP=1` hook that turns every skip (setup/test/collection) into a failure carrying the skip reason — the e2e tests skip silently when Playwright/Chromium/the build is missing, which in CI would be a false green.
- `.gitignore` gains `test-output/`. `call-deploy-book.yml` is untouched. `pull_request` trigger deliberately omitted: push-on-all-branches already attaches the check to same-repo PRs (matching the deploy workflow's convention) and avoids double runs of a Chromium + book-build job.

## Test plan

- Local run of the exact CI sequence from a clean `book/_build`: `pip install -r requirements-dev.txt` → `playwright install chromium` → `teachbooks build book` (36 s, exit 0) → `TESTS_FAIL_ON_SKIP=1 pytest tests -ra -v --junitxml=…`: **58 passed, 0 failed, 0 skipped** in 61 s (37 structure + 2 node wrappers + 1 script-injection + 18 Playwright e2e).
- Skip-gate proof with the build removed: without the env var 27 passed / 31 skipped (exit 0 — the false green); with it 13 failed + 18 setup errors, each naming the skip reason.
- `actionlint` (via `uvx actionlint-py`) and a PyYAML parse of the workflow: clean.
- The real gate is this PR's own `tests` check — this push is its first run.

Closes #39

🤖 Generated with [Claude Code](https://claude.com/claude-code)