### PR TITLE
fix(book): ERD hoofdstuk 1 PRAGMA-cel gebruikt SQL-commentaar (#43)

### DIFF
--- a/book/chapters/ERD/01_Inleiding_tot_ERD.ipynb
+++ b/book/chapters/ERD/01_Inleiding_tot_ERD.ipynb
@@ -245,9 +245,9 @@
     "* Je mag geen orderregel toevoegen voor een product dat niet bestaat.\n",
     "* Je mag geen klant verwijderen als die nog bestellingen heeft (tenzij je cascading instelt).\n",
     "\n",
-    "SQLite kan dit afdwingen via FOREIGN KEY-regels (meer hierover bij DDL).\n",
+    "SQLite kan dit afdwingen via FOREIGN KEY-regels (meer hierover bij DDL), maar alleen als de bewaking van foreign keys **aan** staat. In de SQL-editor op deze website staat ze standaard **uit**.\n",
     "\n",
-    "**Check in webshop.db:**\n"
+    "**Check in webshop.db:** voer de cel hieronder uit met **Run alles**. De eerste controle geeft `0` (uit); daarna zet `PRAGMA foreign_keys = ON;` de bewaking aan en geeft de tweede controle `1`.\n"
    ]
   },
   {
@@ -264,10 +264,23 @@
    },
    "outputs": [],
    "source": [
+    "-- Staat de bewaking van foreign keys aan: 1 = aan, 0 = uit\n",
     "PRAGMA foreign_keys;\n",
     "\n",
-    "# Als dit `0` geeft, voer dan uit:\n",
-    "# PRAGMA foreign_keys = ON;"
+    "-- Op deze website staat ze na elk openen van de pagina (en na Reset db) weer uit.\n",
+    "-- Zet ze aan en controleer opnieuw:\n",
+    "PRAGMA foreign_keys = ON;\n",
+    "PRAGMA foreign_keys;   -- controle: 1 betekent aan"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "dec56bcd",
+   "metadata": {},
+   "source": [
+    ":::{warning}\n",
+    "Deze instelling hoort bij je *verbinding* met de databank, niet bij de databank zelf. Open je deze pagina later opnieuw, of klik je op **Reset db**, dan staat ze weer **uit**. Voer dan eerst opnieuw `PRAGMA foreign_keys = ON;` uit voor je foreign keys test. In hoofdstuk 5 (de cafetaria), waar je zelf foreign keys aanmaakt, kom je hierop terug.\n",
+    ":::\n"
    ]
   },
   {

--- a/tests/test_book_structure.py
+++ b/tests/test_book_structure.py
@@ -1,8 +1,9 @@
 """Structuurtests voor het boek: deelvolgorde, kruisverwijzingen en prev/next-flow (issue #36),
 de plaats van de DB Browser-installatie (issues #33 en #42), de bouwlessen van
-het ERD-deel op de site-editor (issue #42) en de verankering van de
-onderzoekscompetenties in het Big Data-deel (issue #37) en de les kritisch werken
-met AI die daarnaast staat (issue #38).
+het ERD-deel op de site-editor (issue #42), de SQL-commentaarregels in de
+interactieve cellen (issue #43) en de verankering van de onderzoekscompetenties
+in het Big Data-deel (issue #37) en de les kritisch werken met AI die daarnaast
+staat (issue #38).
 
 Draaien met de projectomgeving (PyYAML zit in de teachbooks-installatie):
 
@@ -112,6 +113,15 @@ DOWNLOAD_DB_BUTTON = "Download mijn databank"
 # van de pagina: de cafetaria-les voert de regel in een eigen cel uit en zegt
 # dat je ze na het heropenen van de pagina opnieuw uitvoert.
 FOREIGN_KEYS_ON = "PRAGMA foreign_keys = ON;"
+FOREIGN_KEYS_CHECK = "PRAGMA foreign_keys;"
+
+# Interactieve cellen (issue #43): de editor geeft de celinhoud aan SQLite
+# (sql.js), en SQL kent alleen `--` en `/* … */` als commentaar. Een regel die
+# met `#` of `//` begint is een syntaxfout — met "Run alles" altijd, met Run
+# zodra de cursor op die regel staat. Deze tags markeren de cellen die de
+# editor uitvoert (sql-editors.js).
+SQL_CELL_TAGS = ("sql-db", "sql-live")
+NON_SQL_COMMENT = re.compile(r"^\s*(#|//)")
 
 # Onderzoekscompetenties (issue #37): één pagina in het Big Data-deel definieert
 # zes competenties (C1..C6) met een rubric en een opbouwtabel; elk hoofdstuk
@@ -458,6 +468,44 @@ def test_cafetaria_lesson_switches_foreign_keys_on_in_a_runnable_cell() -> None:
     rel = "chapters/ERD/05_de_cafetaria"
     pragma_cells = [sql for sql in code_cells_tagged(rel, "sql-live") if FOREIGN_KEYS_ON in sql]
     assert len(pragma_cells) >= 2, f"{rel}: {FOREIGN_KEYS_ON} hoort in een eigen cel bij fase 6 én als herinnering bij fase 7"
+    text = source_of(rel)
+    assert re.search(
+        r"opnieuw\b.{0,160}`PRAGMA foreign_keys = ON;`|`PRAGMA foreign_keys = ON;`.{0,160}\bopnieuw\b",
+        text,
+        flags=re.DOTALL,
+    ), f"{rel}: legt niet uit dat je {FOREIGN_KEYS_ON} na het heropenen van de pagina opnieuw uitvoert"
+    assert "Reset db" in text, f"{rel}: noemt Reset db niet (zet de instelling ook uit)"
+
+
+def test_sql_cells_use_only_sql_comments() -> None:
+    """Issue #43: een `#`-regel in een sql-live-cel van ERD hoofdstuk 1 gaf met
+    "Run alles" een syntaxfout in sql.js. Geen enkele sql-db- of sql-live-cel
+    in het boek mag een regel hebben die met `#` of `//` begint."""
+    problems = []
+    for part in ("SQL", "BIG_DATA", "ERD"):
+        for notebook in chapter_notebooks(part):
+            rel = notebook.relative_to(BOOK).with_suffix("").as_posix()
+            for tag in SQL_CELL_TAGS:
+                for n, sql in enumerate(code_cells_tagged(rel, tag), 1):
+                    for line in sql.splitlines():
+                        if NON_SQL_COMMENT.match(line):
+                            problems.append(f"{rel}: {tag}-cel {n}: {line.strip()!r}")
+    assert not problems, "geen SQL-commentaar (gebruik -- of /* … */):\n" + "\n".join(problems)
+
+
+def test_first_erd_page_checks_foreign_keys_like_the_cafetaria_lesson() -> None:
+    """ERD hoofdstuk 1, §5 (#43): de controlecel voert PRAGMA foreign_keys uit,
+    zet de instelling aan zoals hoofdstuk 5 (6.2) en controleert opnieuw — één
+    cel die met "Run alles" 0 en dan 1 laat zien. De tekst zegt, net als daar,
+    dat de instelling na het heropenen van de pagina of Reset db weer uit staat."""
+    rel = FIRST_ERD
+    cells = [sql for sql in code_cells_tagged(rel, "sql-live") if FOREIGN_KEYS_CHECK in sql]
+    assert len(cells) == 1, f"{rel}: verwachtte precies één sql-live-cel met {FOREIGN_KEYS_CHECK}, vond {len(cells)}"
+    sql = cells[0]
+    assert FOREIGN_KEYS_ON in sql, f"{rel}: de controlecel zet de instelling niet aan met {FOREIGN_KEYS_ON}"
+    assert sql.index(FOREIGN_KEYS_CHECK) < sql.index(FOREIGN_KEYS_ON) < sql.rindex(FOREIGN_KEYS_CHECK), (
+        f"{rel}: de controlecel hoort te controleren, aan te zetten en opnieuw te controleren:\n{sql}"
+    )
     text = source_of(rel)
     assert re.search(
         r"opnieuw\b.{0,160}`PRAGMA foreign_keys = ON;`|`PRAGMA foreign_keys = ON;`.{0,160}\bopnieuw\b",

--- a/tests/test_sql_editor.py
+++ b/tests/test_sql_editor.py
@@ -5,7 +5,8 @@ pagina als .sql-bestand en zetten het terug (issues #30/#35). De databank van
 een pagina blijft in de browser bewaard (IndexedDB) en is met "Download mijn
 databank" als .db-bestand te downloaden (issue #41). Daarop draaien de
 bouwlessen van het ERD-deel (hoofdstuk 4 en 5, pagina's zonder seed) volledig
-op de site (issue #42).
+op de site (issue #42). De controlecel voor PRAGMA foreign_keys in ERD
+hoofdstuk 1 loopt met "Run alles" en regel per regel zonder syntaxfout (issue #43).
 
 Twee lagen:
 
@@ -918,5 +919,48 @@ def test_cafetaria_lesson_runs_end_to_end_on_the_site_editor(page, site_url, tmp
             assert sorted((fk[2], fk[6]) for fk in fks) == [("bestellingen", "CASCADE"), ("producten", "RESTRICT")], fks
         finally:
             con.close()
+    finally:
+        context.close()
+
+
+# --- e2e: de foreign_keys-controle in ERD hoofdstuk 1 (#43) -----------------
+
+# Hoofdstuk 1 bevraagt webshop.db (pagina mét seed). De cel bij §5 controleert
+# PRAGMA foreign_keys, zet de instelling aan zoals hoofdstuk 5 (6.2) en
+# controleert opnieuw. Ze bevatte `#`-commentaar, dat SQLite niet kent: met
+# "Run alles" (en met Run zodra de cursor op zo'n regel stond) gaf sql.js een
+# syntaxfout.
+ERD_INTRO_PAGE = "chapters/ERD/01_Inleiding_tot_ERD.html"
+FOREIGN_KEYS_CHECK = "PRAGMA foreign_keys;"
+FOREIGN_KEYS_ON = "PRAGMA foreign_keys = ON;"
+
+
+def run_at_line(page, index: int, needle) -> None:
+    """Klik (zoals een leerling) in de regel van cel `index` die `needle` bevat en druk op Ctrl+Enter."""
+    cell_at(page, index).locator(".cm-line", has_text=needle).click()
+    page.keyboard.press("Control+Enter")
+
+
+def test_erd_intro_foreign_keys_cell_runs_without_syntax_error(page, site_url) -> None:
+    """Op een vers geopende pagina staat de instelling uit: "Run alles" laat
+    0, dan 1 zien, zonder fout. Daarna regel per regel met Run — ook met de
+    cursor op een commentaarregel, die bij het statement erna hoort."""
+    context, fresh = open_fresh(page, site_url, ERD_INTRO_PAGE)
+    try:
+        index = find_cell(fresh, FOREIGN_KEYS_CHECK)
+        assert FOREIGN_KEYS_ON in initial_values(fresh)[index]
+        out = run_cell(fresh, index)
+        expect(out).not_to_contain_text("Fout:")
+        expect(out.locator("th")).to_have_text(["foreign_keys", "foreign_keys"])
+        expect(out.locator("td")).to_have_text(["0", "1"])  # uit → aan
+
+        run_at_line(fresh, index, re.compile(r"^PRAGMA foreign_keys;$"))  # de eerste controle, nu al aan
+        expect(out.locator("td")).to_have_text(["1"])
+        run_at_line(fresh, index, "Zet ze aan")  # commentaarregel: Run voert het statement erna uit
+        expect(out).to_contain_text("OK")
+        expect(out.locator("th")).to_have_count(0)
+        run_at_line(fresh, index, "controle: 1 betekent aan")
+        expect(out.locator("td")).to_have_text(["1"])
+        expect(out).not_to_contain_text("Fout:")
     finally:
         context.close()


### PR DESCRIPTION
## Summary

- **#43** — The `sql-live` cell in ERD ch. 1 §5 (Referentiële integriteit) used `#` comment lines, which sql.js rejects — since #34's "Run alles" (and Run with the cursor on such a line) this surfaced as `unrecognized token: "#"`. The cell now uses `--` comments and checks → sets ON → re-checks (`foreign_keys 0` then `1`); the surrounding text plus a warning admonition mirror ERD ch. 5 §6.2 (the setting is off again after reopening the page or Reset db). A whole-book scan confirmed ch. 1 was the only offender.
- New structure test guards every `sql-db`/`sql-live` cell in the book against `#`/`//` comment lines; new e2e test runs the fixed cell with "Run alles" on the built page.
- The issue's supplementary idea (editor enabling `PRAGMA foreign_keys` by default on pages without an `sql-db` cell) is deliberately left out: it changes editor behaviour and the ch. 5 reminder text, wouldn't apply to the ch. 1 page (which has a seed), and whether students should switch it on themselves is a pedagogical call for the author.

## Test plan

- Clean `teachbooks build book`: 0 WARNING/ERROR.
- `TESTS_FAIL_ON_SKIP=1 pytest tests/test_book_structure.py`: 39 passed (2 new); `TESTS_FAIL_ON_SKIP=1 pytest tests/test_sql_editor.py`: 22 passed (2 node + 1 script-injection + 19 e2e, 1 new); 0 skips.
- Fails-without-fix: both new structure tests fail on the previous notebook; "Run alles" with the old cell text on the real built page gives `Fout: unrecognized token: "#"` vs `foreign_keys 0 / foreign_keys 1` with the fix.
- `nbformat.validate` OK.

Closes #43

🤖 Generated with [Claude Code](https://claude.com/claude-code)